### PR TITLE
optimised stylesheets for common use

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11970,6 +11970,15 @@ textarea.form-control-lg {
   border-color: #6c757e;
 }
 
+.link-style, .link-style:link {
+  color: #6c757e;
+  text-decoration: none;
+}
+
+.link-style:hover, .link-style:active {
+  color: #919294;
+}
+
 .card {
   display: flex;
   flex-direction: column;
@@ -12014,15 +12023,6 @@ textarea.form-control-lg {
 }
 .custom-footer__copyright {
   font-size: 0.7em;
-}
-
-.link-style, link-style:link {
-  color: #6c757e;
-  text-decoration: none;
-}
-
-.link-style:hover, .link-style:active {
-  color: #919294;
 }
 
 .registration-form {

--- a/src/scss/modules/_bootstrapOverwritten.scss
+++ b/src/scss/modules/_bootstrapOverwritten.scss
@@ -1,0 +1,10 @@
+// This stylesheet is for overwritting existing Bootstrap classes that may be used by everyone in the team to ensure everyone has the same style.
+// If you have an element that uses an overwritten class and it needs to be unique or look different, create a unique style for it in your component's stylesheet,
+// e.g. by using a different selector (element, id, class).
+
+@import '_variables.scss';
+
+.form-check-input:checked {
+    background-color: $main-grey;
+    border-color: $main-grey;
+}

--- a/src/scss/modules/_globalCustomClass.scss
+++ b/src/scss/modules/_globalCustomClass.scss
@@ -1,0 +1,13 @@
+// This stylesheet contains custom classes that give style to particular elements.
+// The classes should be used to promote both the coherence of style across the webpage and the reuse of code.
+
+@import '_variables';
+
+.link-style, .link-style:link {
+    color: $main-grey;
+    text-decoration: none;
+}
+
+.link-style:hover, .link-style:active {
+    color: $secondary-grey;
+}

--- a/src/scss/modules/checkboxesOverwritten.scss
+++ b/src/scss/modules/checkboxesOverwritten.scss
@@ -1,6 +1,0 @@
-@import '_variables.scss';
-
-.form-check-input:checked {
-    background-color: $main-grey;
-    border-color: $main-grey;
-}

--- a/src/scss/modules/linkStyle.scss
+++ b/src/scss/modules/linkStyle.scss
@@ -1,8 +1,0 @@
-.link-style, link-style:link {
-    color: $main-grey;
-    text-decoration: none;
-}
-
-.link-style:hover, .link-style:active {
-    color: $secondary-grey;
-}

--- a/src/scss/modules/registrationForm.scss
+++ b/src/scss/modules/registrationForm.scss
@@ -1,6 +1,5 @@
 @import '_mixins.scss';
 @import '_variables';
-@import 'linkStyle';
 
 .registration-form {
     @include size(100%, 100vh);

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,6 +1,6 @@
 @import '~bootstrap';
 @import 'modules/_bootstrapOverwritten';
-@import 'modules/globalCustomClass';
+@import 'modules/_globalCustomClass';
 @import 'sectionAndCards';
 @import 'modules/footer.scss';
 @import 'modules/registrationForm.scss'

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,5 +1,6 @@
 @import '~bootstrap';
-@import 'modules/checkboxesOverwritten.scss';
+@import 'modules/_bootstrapOverwritten';
+@import 'modules/globalCustomClass';
 @import 'sectionAndCards';
 @import 'modules/footer.scss';
 @import 'modules/registrationForm.scss'


### PR DESCRIPTION
Inside src/scss/modules, we now have the following stylesheets:

1. _bootstrapOverwritten:
- This stylesheet is for overwritting existing Bootstrap classes that may be used by everyone in the team to ensure everyone has the same style.
- If you have an element that uses an overwritten class and it needs to be unique or look different, create a unique style for it in your component's stylesheet, e.g. by using a different selector (element, id, class).

2. _globalCustomClass:
- This stylesheet contains custom classes that give style to particular elements.
- The classes should be used to promote both the coherence of style across the webpage and the reuse of code.